### PR TITLE
chore: betteralign on the ten structs that drifted

### DIFF
--- a/internal/adapter/driven/ratelimitbreaker/breaker.go
+++ b/internal/adapter/driven/ratelimitbreaker/breaker.go
@@ -53,6 +53,9 @@ type Config struct {
 	// Limiter is the store to protect. Required.
 	Limiter ratelimit.Limiter
 
+	// OnStateChange is called on each transition, for a gauge or a log. Optional.
+	OnStateChange func(open bool)
+
 	// Threshold is how many CONSECUTIVE failures open the breaker. Zero or less
 	// disables it, which means accepting a failed round trip on every request
 	// during an outage.
@@ -61,9 +64,6 @@ type Config struct {
 	// Cooldown is how long the breaker stays open before letting one request
 	// through to test the store.
 	Cooldown time.Duration
-
-	// OnStateChange is called on each transition, for a gauge or a log. Optional.
-	OnStateChange func(open bool)
 }
 
 // Breaker is a [ratelimit.Limiter] that stops calling a failing store.
@@ -75,18 +75,19 @@ type Config struct {
 // back at a store that is still down, which is how a recovering datastore is
 // knocked over again by the traffic that was waiting for it.
 type Breaker struct {
+	openUntil time.Time
+
 	limiter   ratelimit.Limiter
 	onChange  func(open bool)
 	threshold int
 	cooldown  time.Duration
 
+	consecutiveFailures int
+
 	// mu guards the whole state machine. A mutex rather than atomics because
 	// the transitions are multi-field and must agree with each other; the cost
 	// is nanoseconds against a network call it is often avoiding entirely.
 	mu sync.Mutex
-
-	consecutiveFailures int
-	openUntil           time.Time
 
 	// probing is true while a half-open request is in flight, so a burst does
 	// not send a thousand probes at a store that is still down.

--- a/internal/adapter/driven/ratelimitmemory/adapter.go
+++ b/internal/adapter/driven/ratelimitmemory/adapter.go
@@ -21,9 +21,9 @@ type Adapter struct {
 }
 
 type entry struct {
+	seen    time.Time
 	limiter ratelimiter.Limiter
 	budget  ratelimit.Budget
-	seen    time.Time
 }
 
 // New creates an in-process limiter.

--- a/internal/adapter/driving/http/payload/idps.go
+++ b/internal/adapter/driving/http/payload/idps.go
@@ -45,6 +45,8 @@ type IDPResponse struct {
 //
 //	@Description	Request payload for creating a new identity provider configuration
 type CreateIDPRequest struct {
+	Enabled       *bool     `json:"enabled,omitempty" example:"true" validate:"optional"`                                                                                        // Defaults to true
+	AutoProvision *bool     `json:"auto_provision,omitempty" example:"true" validate:"optional"`                                                                                 // Defaults to true
 	Name          string    `json:"name" example:"Google" format:"string" validate:"required" minLength:"2" maxLength:"100"`                                                     // Display name
 	Description   string    `json:"description" example:"Google OAuth2 Identity Provider" format:"string" validate:"required" minLength:"10" maxLength:"500"`                    // Description
 	CallbackURL   string    `json:"callback_url" example:"http://localhost:8080/api/v1/auth/idp/019b4b0d-a682-7e19-a524-866cfffef121/callback" format:"uri" validate:"required"` // OAuth callback URL
@@ -52,8 +54,6 @@ type CreateIDPRequest struct {
 	ClientID      string    `json:"client_id" example:"367082405970-example" format:"string" validate:"required" minLength:"2" maxLength:"255"`                                  // OAuth client ID
 	ClientSecret  string    `json:"client_secret" example:"GOCSPX-example_secret_key" format:"string" validate:"required" minLength:"2" maxLength:"255"`                         // OAuth client secret
 	IssuerURL     string    `json:"issuer_url,omitempty" example:"https://accounts.google.com" format:"uri" validate:"optional"`                                                 // Required for an oidc kind; the value the ID token's iss must equal
-	Enabled       *bool     `json:"enabled,omitempty" example:"true" validate:"optional"`                                                                                        // Defaults to true
-	AutoProvision *bool     `json:"auto_provision,omitempty" example:"true" validate:"optional"`                                                                                 // Defaults to true
 	ID            uuid.UUID `json:"id,omitempty" example:"019b4b0d-a682-7e19-a524-866cfffef121" format:"uuid" validate:"optional"`                                               // Optional custom ID
 	IDPTypeID     uuid.UUID `json:"idp_type_id" example:"019b4b0d-a682-7e1d-bd83-3864c7d5aa43" format:"uuid" validate:"required"`                                                // Identity provider type ID
 }
@@ -191,8 +191,8 @@ type IDPRegisterResponse struct {
 //	@Description	The outcome of a provider callback: a session for login and register, the linked account for link
 type IDPCallbackResponse struct {
 	Login    *LoginUserResponse `json:"login,omitempty"`                                                                  // The session, for login and register
-	Event    string             `json:"event" example:"login" format:"string" enum:"login,register,link"`                 // Which event the state was minted for
 	LinkedTo *uuid.UUID         `json:"linked_to,omitempty" example:"019b4b0d-a682-7e34-a20c-c71a7147d7e7" format:"uuid"` // The account, for link
+	Event    string             `json:"event" example:"login" format:"string" enum:"login,register,link"`                 // Which event the state was minted for
 }
 
 // UserIdentityResponse is one provider identity linked to the caller's account.

--- a/internal/adapter/driving/http/payload/rate_limits.go
+++ b/internal/adapter/driving/http/payload/rate_limits.go
@@ -127,12 +127,6 @@ type EffectiveRateLimitsResponse struct {
 	Method   string `json:"method" example:"POST" format:"string"`
 	Endpoint string `json:"endpoint" example:"/projects/{project_id}/generate" format:"string"`
 
-	// Enforcing is false when ratelimit.enabled=false: the rules below are real
-	// and editable, and nothing is applying them. A client that renders the
-	// rules without rendering this tells an operator a limit is in place that
-	// is not.
-	Enforcing bool `json:"enforcing" example:"true"`
-
 	// BucketKey states what a budget is keyed on, because "10 per minute" alone
 	// does not say per what. A rule's verbs share one budget; each of its windows
 	// gets its own.
@@ -142,6 +136,12 @@ type EffectiveRateLimitsResponse struct {
 	// IP rule and a project rule both apply, and neither substitutes for the
 	// other.
 	Effective []EffectiveRateLimitEntry `json:"effective"`
+
+	// Enforcing is false when ratelimit.enabled=false: the rules below are real
+	// and editable, and nothing is applying them. A client that renders the
+	// rules without rendering this tells an operator a limit is in place that
+	// is not.
+	Enforcing bool `json:"enforcing" example:"true"`
 }
 
 // ToRateLimitResponse maps a domain rule onto the wire shape.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -46,6 +46,36 @@ var apiPrefix = fmt.Sprintf("api/%s", apiVersion)
 //
 // For testing, use NewAppBuilder to inject mock dependencies.
 type App struct {
+	// A ratelimit.Limiter, not the concrete Valkey adapter: it is wrapped in a
+	// circuit breaker, so the concrete type is no longer what is stored.
+	rateLimitShared ratelimit.Limiter
+
+	// rateLimitNotifier propagates a rule write to the other replicas. nil
+	// without a cache, which is a supported deployment -- the reload ticker is
+	// the floor and this only removes the wait.
+	rateLimitNotifier ratelimit.ChangeNotifier
+
+	// tokenLifetimesNotifier propagates a PUT /auth/token_lifetimes to the
+	// other replicas. Same shape and same "nil without a cache" as the
+	// rate-limit one.
+	tokenLifetimesNotifier changenotify.Notifier
+
+	// changeNotifyValkey is the subscriber client every change notifier shares.
+	// Separate from cacheClient because a subscribed connection accepts
+	// nothing else; owned here so shutdown closes it once.
+	changeNotifyValkey valkey.Client
+
+	// The JWT signer, held so the HTTP middleware's validators verify tokens
+	// through the same routine the use-cases do. The middleware used to carry
+	// its own implementation, and the two disagreed about what to check.
+	tokenSigner token.Signer
+
+	// Valkey client backing the cache (nil when cache.enabled is false).
+	// Held here for two reasons the cache.Cache port cannot serve: the
+	// connection pool and its background goroutines have to be closed on
+	// shutdown, and the health check needs to PING the server directly.
+	cacheClient valkey.Client
+
 	// Configuration loaded from flags and environment
 	configs *Configs
 
@@ -72,40 +102,8 @@ type App struct {
 	// enforced — it is the limiter when cache.enabled is false, and the layer in
 	// front of the shared counter when it is not. rateLimitShared is nil without
 	// a cache client, and every rule is then per replica.
-	rateLimitLocal *ratelimitmemory.Adapter
-	// A ratelimit.Limiter, not the concrete Valkey adapter: it is wrapped in a
-	// circuit breaker, so the concrete type is no longer what is stored.
-	rateLimitShared ratelimit.Limiter
-
-	// rateLimitNotifier propagates a rule write to the other replicas. nil
-	// without a cache, which is a supported deployment -- the reload ticker is
-	// the floor and this only removes the wait.
-	rateLimitNotifier ratelimit.ChangeNotifier
-	rateLimitMetrics  *middleware.RateLimitMetrics
-
-	// tokenLifetimesNotifier propagates a PUT /auth/token_lifetimes to the
-	// other replicas. Same shape and same "nil without a cache" as the
-	// rate-limit one.
-	tokenLifetimesNotifier changenotify.Notifier
-
-	// changeNotifyValkey is the subscriber client every change notifier shares.
-	// Separate from cacheClient because a subscribed connection accepts
-	// nothing else; owned here so shutdown closes it once.
-	changeNotifyValkey valkey.Client
-
-	// replicaID names this process in the change messages it publishes.
-	replicaID string
-
-	// The JWT signer, held so the HTTP middleware's validators verify tokens
-	// through the same routine the use-cases do. The middleware used to carry
-	// its own implementation, and the two disagreed about what to check.
-	tokenSigner token.Signer
-
-	// Valkey client backing the cache (nil when cache.enabled is false).
-	// Held here for two reasons the cache.Cache port cannot serve: the
-	// connection pool and its background goroutines have to be closed on
-	// shutdown, and the health check needs to PING the server directly.
-	cacheClient valkey.Client
+	rateLimitLocal   *ratelimitmemory.Adapter
+	rateLimitMetrics *middleware.RateLimitMetrics
 
 	// Application layers (organized by architectural layer)
 	repositories *Repositories // Data access layer
@@ -119,8 +117,12 @@ type App struct {
 	startupMetrics *StartupMetrics // Startup performance metrics
 
 	// Lifecycle management
-	shutdownCh   chan struct{} // Channel to signal shutdown
-	shutdownOnce sync.Once     // Ensures shutdown only happens once
+	shutdownCh chan struct{} // Channel to signal shutdown
+
+	// replicaID names this process in the change messages it publishes.
+	replicaID string
+
+	shutdownOnce sync.Once // Ensures shutdown only happens once
 }
 
 // authKeys holds the cryptographic keys used for authentication

--- a/internal/core/domain/authn.go
+++ b/internal/core/domain/authn.go
@@ -264,13 +264,13 @@ func (ref *RecoverPasswordInput) Validate() error {
 }
 
 type ResetPasswordInput struct {
-	Password string    `json:"password" format:"string" example:"ThisIs4Passw0rd" validate:"required"`
-	UserID   uuid.UUID `json:"user_id" format:"uuid" example:"01982303-f0f9-7dd3-9b51-779cddf01211" validate:"required"`
+	TokenExpiresAt time.Time `json:"-"`
+	Password       string    `json:"password" format:"string" example:"ThisIs4Passw0rd" validate:"required"`
+	UserID         uuid.UUID `json:"user_id" format:"uuid" example:"01982303-f0f9-7dd3-9b51-779cddf01211" validate:"required"`
 	// TokenID and TokenExpiresAt identify the reset token being spent. A
 	// reset link is single-use: the jti is recorded in the revoked-token store
 	// the first time and refused after, until the token would have expired.
-	TokenID        uuid.UUID `json:"-"`
-	TokenExpiresAt time.Time `json:"-"`
+	TokenID uuid.UUID `json:"-"`
 }
 
 func (ref *ResetPasswordInput) Validate() error {
@@ -287,6 +287,7 @@ func (ref *ResetPasswordInput) Validate() error {
 }
 
 type LogoutUserInput struct {
+	AccessTokenExpiresAt time.Time
 
 	// RefreshToken is the token to revoke, and it is what makes logout end a
 	// session rather than merely say it did.
@@ -311,8 +312,7 @@ type LogoutUserInput struct {
 	//
 	// Zero when the caller authenticated with a personal access token, which is
 	// revoked by deleting its row rather than by a denylist entry.
-	AccessTokenJTI       uuid.UUID
-	AccessTokenExpiresAt time.Time
+	AccessTokenJTI uuid.UUID
 }
 
 func (ref *LogoutUserInput) Validate() error {

--- a/internal/core/domain/policies.go
+++ b/internal/core/domain/policies.go
@@ -100,11 +100,11 @@ type Policy struct {
 }
 
 type LinkRolesToPolicyInput struct {
+	RoleIDs []uuid.UUID
 	// CallerID is who is granting; the guard checks they hold what they hand
 	// out, and refuses a zero value. Unlink paths share this input and leave it
 	// zero: nothing is granted there.
 	CallerID uuid.UUID
-	RoleIDs  []uuid.UUID
 	PolicyID uuid.UUID
 }
 
@@ -189,14 +189,14 @@ type SelectPoliciesOutput struct {
 type ListPoliciesOutput = SelectPoliciesOutput
 
 type CreatePolicyInput struct {
-	// CallerID is who is granting; the guard checks they hold what they hand out.
-	CallerID        uuid.UUID
 	Name            string
 	Description     string
 	AllowedAction   string
 	AllowedResource string
-	ID              uuid.UUID
-	ResourceID      uuid.UUID
+	// CallerID is who is granting; the guard checks they hold what they hand out.
+	CallerID   uuid.UUID
+	ID         uuid.UUID
+	ResourceID uuid.UUID
 }
 
 func (ref *CreatePolicyInput) Validate() error {
@@ -244,13 +244,13 @@ func (ref *CreatePolicyInput) Validate() error {
 }
 
 type UpdatePolicyInput struct {
-	// CallerID is who is granting; the guard checks they hold what they hand out.
-	CallerID        uuid.UUID
 	Name            *string
 	Description     *string
 	AllowedAction   *string
 	AllowedResource *string
-	ID              uuid.UUID
+	// CallerID is who is granting; the guard checks they hold what they hand out.
+	CallerID uuid.UUID
+	ID       uuid.UUID
 }
 
 func (ref *UpdatePolicyInput) Validate() error {

--- a/internal/core/domain/roles.go
+++ b/internal/core/domain/roles.go
@@ -199,11 +199,11 @@ type SelectRolesOutput struct {
 type ListRolesOutput = SelectRolesOutput
 
 type LinkUsersToRoleInput struct {
+	UserIDs []uuid.UUID
 	// CallerID is who is granting; the guard checks they hold what they hand
 	// out, and refuses a zero value. Unlink paths share this input and leave it
 	// zero: nothing is granted there.
 	CallerID uuid.UUID
-	UserIDs  []uuid.UUID
 	RoleID   uuid.UUID
 }
 
@@ -234,10 +234,10 @@ func (ref *LinkUsersToRoleInput) Validate() error {
 type UnlinkUsersFromRoleInput = LinkUsersToRoleInput
 
 type LinkPoliciesToRoleInput struct {
-	// CallerID is who is granting; the guard checks they hold what they hand out.
-	CallerID  uuid.UUID
 	PolicyIDs []uuid.UUID
-	RoleID    uuid.UUID
+	// CallerID is who is granting; the guard checks they hold what they hand out.
+	CallerID uuid.UUID
+	RoleID   uuid.UUID
 }
 
 func (ref *LinkPoliciesToRoleInput) Validate() error {

--- a/internal/core/domain/users.go
+++ b/internal/core/domain/users.go
@@ -266,11 +266,11 @@ type SelectUsersOutput struct {
 type ListUsersOutput = SelectUsersOutput
 
 type LinkRolesToUserInput struct {
+	RoleIDs []uuid.UUID
 	// CallerID is who is granting; the guard checks they hold what they hand
 	// out, and refuses a zero value. Unlink paths share this input and leave it
 	// zero: nothing is granted there.
 	CallerID uuid.UUID
-	RoleIDs  []uuid.UUID
 	UserID   uuid.UUID
 }
 

--- a/internal/core/usecase/rate_limits_mirror.go
+++ b/internal/core/usecase/rate_limits_mirror.go
@@ -59,13 +59,14 @@ type RateLimitRules struct {
 	// on the request path.
 	rules atomic.Pointer[[]domain.RateLimit]
 
+	ot *o11y.OpenTelemetry
+
 	lastReload     atomic.Int64
 	reloadFailures atomic.Int64
-	loaded         atomic.Bool
 
 	reloadInterval time.Duration
 
-	ot *o11y.OpenTelemetry
+	loaded atomic.Bool
 }
 
 // NewRateLimitRules creates the mirror. It does NOT load: the first load happens


### PR DESCRIPTION
`make go-betteralign` rewrote these ten structs on untouched `main` and exited 1, so every branch's post-change checklist kept pulling the same files into unrelated PRs. This is that rewrite on its own: field order only, every comment travelling with its field.

A `chore` title skips the CI gates, so they were run locally: `go-fmt`, `go-betteralign` (now clean), `lint`, `build`, `test`, `vulncheck` and `licenses-check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
